### PR TITLE
feat: bypass body serialization if body type is data

### DIFF
--- a/Sources/NClient/Endpoint.swift
+++ b/Sources/NClient/Endpoint.swift
@@ -36,7 +36,7 @@ public protocol Endpoint {
     func url(parameters: Parameters) -> URLComponents
 
     /// Serializes the request body into the given URLRequest.
-    func serializeBody(_ body: RequestBody, contentType: HTTP.MIMEType, into request: inout URLRequest) throws
+    func serializeBody(_ body: RequestBody, into request: inout URLRequest) throws
 
     /// Deserializes the response body from the received data.
     func deserializeBody(_ data: Data) throws -> ResponseBody
@@ -79,7 +79,7 @@ public extension Endpoint {
         var request = URLRequest(url: url.absoluteURL)
         request.httpMethod = method.rawValue
         request.setHeader(.accept, value: HTTP.MIMEType.json.rawValue)
-        try serializeBody(requestBody, contentType: contentType, into: &request)
+        try serializeBody(requestBody, into: &request)
         
         return request
     }
@@ -89,12 +89,12 @@ public extension Endpoint {
 
 public extension Endpoint where RequestBody == Empty {
     /// No implementation in case of empty request body.
-    func serializeBody(_ body: RequestBody, contentType: HTTP.MIMEType, into request: inout URLRequest) throws {}
+    func serializeBody(_ body: RequestBody, into request: inout URLRequest) throws {}
 }
 
 public extension Endpoint where RequestBody: Encodable {
     /// Serializes an encodable request body as JSON.
-    func serializeBody(_ body: RequestBody, contentType: HTTP.MIMEType, into request: inout URLRequest) throws {
+    func serializeBody(_ body: RequestBody, into request: inout URLRequest) throws {
         request.setHeader(.contentType, value: contentType.rawValue)
         let data = try JSONEncoder().encode(body)
         request.httpBody = data
@@ -103,7 +103,7 @@ public extension Endpoint where RequestBody: Encodable {
 
 public extension Endpoint where RequestBody == Data {
     /// Bypass serialization if request body is already of Data type
-    func serializeBody(_ body: RequestBody, contentType: HTTP.MIMEType, into request: inout URLRequest) throws {
+    func serializeBody(_ body: RequestBody, into request: inout URLRequest) throws {
         request.setHeader(.contentType, value: contentType.rawValue)
         request.httpBody = body
     }

--- a/Sources/NClient/HTTP.swift
+++ b/Sources/NClient/HTTP.swift
@@ -18,16 +18,14 @@ public enum HTTP {
     struct HeaderName: RawRepresentable {
         let rawValue: String
     }
-}
 
-extension HTTP {
-    /// Represents common MIME types used in HTTP requests and responses.
-    enum MIMEType {
-        /// JSON data.
-        static let json = "application/json"
+    /// Supported MIME types
+    public struct MIMEType: RawRepresentable {
+        public let rawValue: String
 
-        /// URL-encoded form data.
-        static let formUrlEncoded = "application/x-www-form-urlencoded"
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
     }
 }
 
@@ -43,6 +41,17 @@ extension HTTP.HeaderName {
 
     /// The "Content-Type" header name.
     static let contentType = HTTP.HeaderName("Content-Type")
+}
+
+public extension HTTP.MIMEType {
+    /// JSON data.
+    static let json = HTTP.MIMEType(rawValue: "application/json")
+
+    /// URL-encoded form data.
+    static let formUrlEncoded = HTTP.MIMEType(rawValue: "application/x-www-form-urlencoded")
+
+    /// MP4
+    static let mp4 = HTTP.MIMEType(rawValue: "audio/mp4")
 }
 
 extension URLRequest {

--- a/Tests/NClientTests/Unit/APIClientTests.swift
+++ b/Tests/NClientTests/Unit/APIClientTests.swift
@@ -35,7 +35,7 @@ final class APIClientTests: XCTestCase {
             result: .success(
                 .init(
                     statusCode: 200,
-                    headers: [HTTP.HeaderName.contentType.rawValue: HTTP.MIMEType.json],
+                    headers: [HTTP.HeaderName.contentType.rawValue: HTTP.MIMEType.json.rawValue],
                     data: mockResponseData
                 )
             )

--- a/Tests/NClientTests/Unit/EndpointTests.swift
+++ b/Tests/NClientTests/Unit/EndpointTests.swift
@@ -20,7 +20,7 @@ final class EndpointTests: XCTestCase {
         XCTAssertEqual(request.url?.absoluteString, "https://example.com/path")
         XCTAssertEqual(request.httpMethod, HTTP.Method.GET.rawValue)
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.accept.rawValue), HTTP.MIMEType.json)
+        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.accept.rawValue), HTTP.MIMEType.json.rawValue)
         XCTAssertNil(request.value(forHTTPHeaderField: HTTP.HeaderName.contentType.rawValue))
 
         XCTAssertNil(request.httpBody)
@@ -48,12 +48,30 @@ final class EndpointTests: XCTestCase {
         XCTAssertEqual(request.url?.absoluteString, "https://example.com/path")
         XCTAssertEqual(request.httpMethod, HTTP.Method.POST.rawValue)
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.accept.rawValue), HTTP.MIMEType.json)
-        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.contentType.rawValue), HTTP.MIMEType.json)
+        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.accept.rawValue), HTTP.MIMEType.json.rawValue)
+        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.contentType.rawValue), HTTP.MIMEType.json.rawValue)
 
         let bodyData = try JSONEncoder().encode(mockRequestBody)
         XCTAssertNotNil(request.httpBody)
         XCTAssertEqual(request.httpBody, bodyData)
+    }
+
+    func testEndpointWithRawRequestBody() throws {
+        let endpoint = MockEndpointWithRawResponseBody()
+        let request = try endpoint.request(
+            baseUrl: mockBaseUrl,
+            parameters: .empty,
+            requestBody: try XCTUnwrap(mockMessage.data(using: .utf8))
+        )
+
+        XCTAssertEqual(request.url?.absoluteString, "https://example.com/path")
+        XCTAssertEqual(request.httpMethod, HTTP.Method.POST.rawValue)
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.accept.rawValue), HTTP.MIMEType.json.rawValue)
+        XCTAssertEqual(request.value(forHTTPHeaderField: HTTP.HeaderName.contentType.rawValue), HTTP.MIMEType.mp4.rawValue)
+
+        let requestBody = try XCTUnwrap(request.httpBody)
+        XCTAssertEqual(String(data: requestBody, encoding: .utf8), mockMessage)
     }
 
     // MARK: Deserialize
@@ -135,6 +153,22 @@ private struct MockEndpointWithRequestBody: Endpoint {
 
 private struct MockEndpointWithResponseBody: Endpoint {
     typealias ResponseBody = MockResponseBody
+
+    func url(parameters: Parameters) -> URLComponents {
+        .init(path: mockPath)
+    }
+}
+
+private struct MockEndpointWithRawResponseBody: Endpoint {
+    typealias RequestBody = Data
+
+    var method: HTTP.Method {
+        .POST
+    }
+
+    var contentType: HTTP.MIMEType {
+        .mp4
+    }
 
     func url(parameters: Parameters) -> URLComponents {
         .init(path: mockPath)


### PR DESCRIPTION
- Added support to indicate other content types in request body different than json

Note, my branch is taken from tag 1.0.0

Resolves #10 